### PR TITLE
Backwards Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const middleware = playdoh(options)
 
 ## Options
 
-**`protocol`** - Defaults to `udp4.` Can be either `udp4` or `udp6` to indicate whether to connect to the resolver over IPv4 or IPv6 respectively.
+**`protocol`** - Defaults to `udp4`. Can be either `udp4` or `udp6` to indicate whether to connect to the resolver over IPv4 or IPv6 respectively.
 
 **`localAddress`** - Defaults to `localhost`. The UDP socket is bound to this address. Use a local-only address (`localhost`, `127.0.0.1` or `::1`) to only accept local DNS resolver responses. Set to empty string to bind to all addresses (`0.0.0.0` or `::0`) and accept remote DNS resolver responses.
 

--- a/test/helpers/eventToPromise.js
+++ b/test/helpers/eventToPromise.js
@@ -1,11 +1,11 @@
 function eventToPromise (emitter, success, failure = 'error') {
   return new Promise((resolve, reject) => {
     function onSuccess (value) {
-      emitter.off(failure, onFailure)
+      emitter.removeListener(failure, onFailure)
       resolve(value)
     }
     function onFailure (error) {
-      emitter.off(success, onSuccess)
+      emitter.removeListener(success, onSuccess)
       reject(error)
     }
     emitter.once(success, onSuccess)


### PR DESCRIPTION
Problem: We can't use some of the new Node.js 10 fancy syntax and APIs just yet.

Reason: The Commons Host server needs to support Node.js 8 LTS because web developers may (should?) be still using LTS locally.

Solution: Use legacy methods for streams, events, URL, etc.

Fixes: https://gitlab.com/sebdeckers/server/-/jobs/99595976