### PR TITLE
DNS Poisoning by UDP Spoofing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,69 @@ Note: HTTP/2 is the minimum *recommended* version of HTTP for use with DoH.
 
 ```js
 const { playdoh } = require('playdoh')
+
+// Defaults
 const options = {
-  // Defaults
+  // udp4 (IPv4) or udp6 (IPv6)
   protocol: 'udp4',
-  localAddress: 'localhost',
+
+  // Defaults to 0.0.0.0 (udp4) or ::0 (udp6)
+  localAddress: '',
+
+  // Defaults to 127.0.0.1 (udp4) or ::1 (udp6)
   resolverAddress: '',
+
+  // Standard DNS port
   resolverPort: 53,
+
+  // Maximum DNS lookup duration
   timeout: 10000
 }
+
 const middleware = playdoh(options)
 ```
 
+## Returns: `middleware(request, response, next)`
+
+The middleware function follows the Node.js convention and is compatible with most popular web server frameworks.
+
 ## Options
 
-**`protocol`** - Defaults to `udp4`. Can be either `udp4` or `udp6` to indicate whether to connect to the resolver over IPv4 or IPv6 respectively.
+### `protocol`
 
-**`localAddress`** - Defaults to `localhost`. The UDP socket is bound to this address. Use a local-only address (`localhost`, `127.0.0.1` or `::1`) to only accept local DNS resolver responses. Set to empty string to bind to all addresses (`0.0.0.0` or `::0`) and accept remote DNS resolver responses.
+Default: `udp4`
 
-**`resolverAddress`** - Defaults to `127.0.0.1` or `::1`. The IP address of the DNS resolver. Queries are sent via UDP. See also: [List of public DNS service operators](https://en.wikipedia.org/wiki/Public_recursive_name_server) on Wikipedia.
+Can be either `udp4` or `udp6` to indicate whether to connect to the resolver over IPv4 or IPv6 respectively.
 
-**`resolverPort`** - Defaults to `53`. The port of the DNS resolver.
+### `localAddress`
 
-**`timeout`** - Defaults to `10000`. Number of milliseconds to wait for a response from the DNS resolver.
+Default: `0.0.0.0` (IPv4) or `::0` (IPv6)
+
+The UDP socket is bound to this address.
+
+Use a loopback IP address (`''` empty string, `localhost`, `127.0.0.1`, or `::1`) to only accept local DNS resolver responses.
+
+Use a wildcard IP address (`0.0.0.0` or `::0`) to accept remote DNS resolver responses.
+
+### `resolverAddress`
+
+Default: `127.0.0.1` (IPv4) or `::1` (IPv6)
+
+The IP address of the DNS resolver. Queries are sent via UDP.
+
+See also: [List of public DNS service operators](https://en.wikipedia.org/wiki/Public_recursive_name_server) on Wikipedia.
+
+### `resolverPort`
+
+Default: `53`
+
+The port of the DNS resolver.
+
+### `timeout`
+
+Default: `10000`
+
+Number of milliseconds to wait for a response from the DNS resolver.
 
 ### Connect
 

--- a/test/helpers/packet.js
+++ b/test/helpers/packet.js
@@ -1,0 +1,26 @@
+const dnsPacket = require('dns-packet')
+
+module.exports.query = (packet = {}) => dnsPacket.encode({
+  type: 'query',
+  id: 0,
+  flags: dnsPacket.RECURSION_DESIRED,
+  questions: [{
+    type: 'A',
+    class: 'IN',
+    name: 'www.example.com'
+  }],
+  ...packet
+})
+
+module.exports.response = (packet = {}) => dnsPacket.encode({
+  id: 0,
+  type: 'response',
+  answers: [{
+    type: 'A',
+    class: 'IN',
+    flush: true,
+    name: 'www.example.com',
+    data: '10.10.10.10'
+  }],
+  ...packet
+})

--- a/test/randomised-dns-header-id.js
+++ b/test/randomised-dns-header-id.js
@@ -1,0 +1,61 @@
+const test = require('blue-tape')
+const { playdoh } = require('..')
+const { promisify } = require('util')
+const connect = require('connect')
+const http2 = require('http2')
+const { decode } = require('dns-packet')
+const { fetch } = require('./helpers/fetch')
+const { createSocket } = require('dgram')
+const { query, response } = require('./helpers/packet')
+
+let resolver
+test('Start mock resolver', async (t) => {
+  resolver = createSocket('udp4')
+  resolver.bind()
+  resolver.once('message', (message, { port, address }) => {
+    const { id } = decode(message)
+    t.isNot(id, dohRequestId)
+    const res = response({ id })
+    resolver.send(res, port, address)
+  })
+})
+
+let server
+let baseUrl
+test('Start server with DOH middleware', async (t) => {
+  const options = {
+    resolverPort: resolver.address().port
+  }
+  const middleware = playdoh(options)
+
+  const app = connect()
+  app.use(middleware)
+  server = http2.createServer(app)
+  await promisify(server.listen).call(server)
+  const { port } = server.address()
+  baseUrl = `http://localhost:${port}`
+})
+
+let dohRequestId
+test('DOH using HTTP/2 POST request', async (t) => {
+  dohRequestId = Math.floor(Math.random() * 2 ** 16)
+
+  const response = await fetch(baseUrl, {
+    headers: {
+      ':method': 'POST',
+      'accept': 'application/dns-message'
+    },
+    body: query({ id: dohRequestId })
+  })
+
+  const { id } = decode(await response.buffer())
+  t.is(id, dohRequestId)
+})
+
+test('Stop server', (t) => {
+  server.close(t.end)
+})
+
+test('Stop mock resolver', (t) => {
+  resolver.close(t.end)
+})


### PR DESCRIPTION
Randomising the DNS header ID field helps reject spoofed DNS responses. There is negligible performance cost (mainly generating 2 random bytes).

DOH recommends the ID is always 0. When Playdoh waits for responses from the DNS resolver, an attacker could send a UDP packet with spoofed source address and assume the DNS header ID is 0. Adding a cryptographically random 16-bit ID makes this attack that much harder.

Other mitigating factors:
- Commons Host Playdoh is only listening on the loopback address for responses from the local Knot Resolver.
- DNSSEC is supported by Knot Resolver.
- NAT prevents UDP spoofing.
- Most ISPs prevent UDP source spoofing.

## References

- https://en.wikipedia.org/wiki/DNS_spoofing

- https://en.wikipedia.org/wiki/Dan_Kaminsky#Flaw_in_DNS

- https://www.cisco.com/c/en/us/about/security-center/dns-best-practices.html