### PR TITLE
Cluster UDP

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -111,7 +111,7 @@ function playdoh ({
     let socket
     try {
       socket = createSocket(protocol)
-      socket.bind(localAddress)
+      socket.bind({ address: localAddress, exclusive: true })
     } catch (error) {
       return next(new InternalServerError())
     }

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,0 +1,39 @@
+const test = require('blue-tape')
+const cluster = require('cluster')
+const { join } = require('path')
+const { eventToPromise } = require('./helpers/eventToPromise')
+const { fetch } = require('./helpers/fetch')
+const { query } = require('./helpers/packet')
+
+const bombardment = 200 // macOS defaults to very low ulimit
+
+test('Barrage workers with requests', async (t) => {
+  const workers = []
+  cluster.setupMaster({ exec: join(__dirname, 'helpers/worker.js') })
+  for (let count = 0; count < 8; count++) {
+    const worker = cluster.fork()
+    workers.push(worker)
+  }
+  await Promise.all(workers.map((worker) => {
+    return eventToPromise(worker, 'listening')
+  }))
+  const lookups = []
+  for (let count = 0; count < bombardment; count++) {
+    const url = `http://localhost:8000/${count}`
+    const headers = {
+      ':method': 'POST',
+      'accept': 'application/dns-message'
+    }
+    const body = query()
+    const request = fetch(url, { headers, body })
+    lookups.push(request)
+  }
+  const responses = await Promise.all(lookups)
+  t.ok(responses.every(({ ok }) => ok))
+  for (const worker of workers) {
+    worker.kill()
+  }
+  await Promise.all(workers.map((worker) => {
+    return eventToPromise(worker, 'exit')
+  }))
+})

--- a/test/helpers/dnsServer.js
+++ b/test/helpers/dnsServer.js
@@ -1,0 +1,10 @@
+const { getServers } = require('dns')
+
+module.exports.dnsServer = function () {
+  const dnsServers = getServers()
+  if (dnsServers.length === 0) {
+    throw new Error('No dns servers available.')
+  }
+  const randomIndex = Math.floor(Math.random() * dnsServers.length)
+  return dnsServers[randomIndex]
+}

--- a/test/helpers/fetch.js
+++ b/test/helpers/fetch.js
@@ -27,6 +27,7 @@ async function fetch (url, options) {
   const body = Buffer.concat(chunks)
   chunks.length = 0
   return {
+    ok: headers[':status'] < 400,
     get headers () { return new Map(Object.entries(headers)) },
     async buffer () { return body },
     async text () { return body.toString() },

--- a/test/helpers/worker.js
+++ b/test/helpers/worker.js
@@ -1,0 +1,23 @@
+const { playdoh } = require('../..')
+const { createServer } = require('http2')
+const connect = require('connect')
+const { dnsServer } = require('./dnsServer')
+
+function annotate (message) {
+  return `${process.pid} - ${message}`
+}
+
+const app = connect()
+app.use(playdoh({ resolverAddress: dnsServer() }))
+app.use((request, response, next) => {
+  const error = new Error('Should have been handled by DOH')
+  console.error(annotate(error))
+  next(error)
+})
+app.use((error, request, response, next) => {
+  console.log(annotate(error))
+  next(error)
+})
+
+const server = createServer(app)
+server.listen(8000)

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -7,6 +7,7 @@ const { decode } = require('dns-packet')
 const { fetch } = require('./helpers/fetch')
 const { encode } = require('base64url')
 const { query } = require('./helpers/packet')
+const { dnsServer } = require('./helpers/dnsServer')
 
 let server
 let baseUrl
@@ -14,7 +15,7 @@ test('Start server with DOH middleware', async (t) => {
   const options = {
     protocol: 'udp4',
     localAddress: '0.0.0.0',
-    resolverAddress: '8.8.8.8',
+    resolverAddress: dnsServer(),
     resolverPort: 53,
     timeout: 5000
   }


### PR DESCRIPTION
## Problem

The use of Playdoh in cluster mode on Commons Host was crashing. The dgram module defaults to [sharing sockets](https://github.com/nodejs/node/blob/045b07d51833076ea0e4b2f3d7cce94baaa550a5/lib/internal/cluster/shared_handle.js#L27) across a cluster. DNS response messages were being received by the wrong worker.

```
assert.js:42
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: false == true
    at SharedHandle.add (internal/cluster/shared_handle.js:27:3)
    at queryServer (internal/cluster/master.js:318:10)
    at Worker.onmessage (internal/cluster/master.js:250:5)
    at ChildProcess.onInternalMessage (internal/cluster/utils.js:42:8)
    at emitTwo (events.js:131:20)
    at ChildProcess.emit (events.js:214:7)
    at emit (internal/child_process.js:762:12)
    at _combinedTickCallback (internal/process/next_tick.js:142:11)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```

## Test

Master raises an army of workers and bombards with attacks. (Was listening to Iron Maiden and Hammerfall while coding this. 🤘🏻👨🏻‍🎤)

## Solution

Set the [`exclusive: true` option]() to bind the UDP socket to a single worker.